### PR TITLE
flamapy update and minor fixes

### DIFF
--- a/main_complete_partial_config.py
+++ b/main_complete_partial_config.py
@@ -3,8 +3,8 @@ import os
 import argparse
 import random
 
-from famapy.metamodels.fm_metamodel.transformations.featureide_reader import FeatureIDEReader
-from famapy.metamodels.bdd_metamodel.operations import BDDProductDistributionBF
+from flamapy.metamodels.fm_metamodel.transformations.featureide_reader import FeatureIDEReader
+from flamapy.metamodels.bdd_metamodel.operations import BDDProductDistribution
 
 from montecarlo_framework.algorithms.montecarlo_algorithm import MonteCarloAlgorithm
 from montecarlo_framework.algorithms.stopping_conditions import IterationsStoppingCondition, TimeStoppingCondition, NoneStoppingCondition
@@ -154,7 +154,7 @@ def main(runs: int,
     # This requires the BDD
     # if fm.bdd_model is not None:
     #     try:
-    #         pd = BDDProductDistributionBF().execute(fm.bdd_model).get_result()
+    #         pd = BDDProductDistribution().execute(fm.bdd_model).get_result()
     #     except:
     #         print(f"ERROR: the product distribution cannot be calculated in a brute force way.")
     #         sys.exit()

--- a/main_find_defective_config.py
+++ b/main_find_defective_config.py
@@ -4,8 +4,8 @@ import argparse
 import random
 from collections import defaultdict 
 
-from famapy.metamodels.fm_metamodel.transformations.featureide_reader import FeatureIDEReader
-from famapy.metamodels.bdd_metamodel.operations import BDDProductDistributionBF
+from flamapy.metamodels.fm_metamodel.transformations.featureide_reader import FeatureIDEReader
+from flamapy.metamodels.bdd_metamodel.operations import BDDProductDistribution
 
 from montecarlo_framework.algorithms.montecarlo_algorithm import MonteCarloAlgorithm
 from montecarlo_framework.algorithms.stopping_conditions import IterationsStoppingCondition, TimeStoppingCondition, NoneStoppingCondition
@@ -55,7 +55,7 @@ def main(runs: int,
     unselected_variables = [-fm.sat_model.variables[f.name] for f in unselected_features]
     initial_config = FMConfiguration(fm, selected_features, unselected_features, selected_variables, unselected_variables)
 
-    if input_model in ['aafm-excerpt', 'affm']:
+    if input_model in ['aafm-excerpt', 'aafm']:
         initial_state = DefectiveConfigurationState(initial_config)
         problem = FindingDefectiveConfigProblem(initial_state)
     elif input_model == 'jhipster':

--- a/main_optimize_config.py
+++ b/main_optimize_config.py
@@ -4,8 +4,8 @@ import argparse
 import random
 from collections import defaultdict 
 
-from famapy.metamodels.fm_metamodel.transformations.featureide_reader import FeatureIDEReader
-from famapy.metamodels.bdd_metamodel.operations import BDDProductDistributionBF
+from flamapy.metamodels.fm_metamodel.transformations.featureide_reader import FeatureIDEReader
+from flamapy.metamodels.bdd_metamodel.operations import BDDProductDistribution
 from montecarlo_framework.utils.attributes_csv_reader import AttributesCSVReader
 
 from montecarlo_framework.algorithms.montecarlo_algorithm import MonteCarloAlgorithm
@@ -57,7 +57,7 @@ def main(runs: int,
     unselected_variables = [-fm.sat_model.variables[f.name] for f in unselected_features]
     initial_config = FMConfiguration(fm, selected_features, unselected_features, selected_variables, unselected_variables)
 
-    if input_model in ['aafm-excerpt', 'affm']:
+    if input_model in ['aafm-excerpt', 'aafm']:
         initial_state = OptimizeConfigurationState(initial_config, attributes)
         problem = FindingOptimumConfigProblem(initial_state)
 
@@ -180,7 +180,7 @@ if __name__ == '__main__':
         sys.exit()
 
     if args.feature_model.lower() not in ['aafm-excerpt', 'aafm']:
-        print(f"ERROR: Feature model not recognized. Use: 'aafm-excerpt', 'aafm', or 'jhipster'.")
+        print(f"ERROR: Feature model not recognized. Use: 'aafm-excerpt' or 'aafm'.")
         parser.print_help()
         sys.exit()
 

--- a/main_reverse_engineering.py
+++ b/main_reverse_engineering.py
@@ -6,10 +6,10 @@ from functools import reduce
 from pathlib import Path
 
 
-from famapy.metamodels.fm_metamodel.transformations.featureide_reader import FeatureIDEReader
-from famapy.metamodels.bdd_metamodel.operations import BDDProductDistributionBF
-from famapy.metamodels.fm_metamodel.transformations.uvl_writter import UVLWriter
-from famapy.metamodels.fm_metamodel.models import FeatureModel
+from flamapy.metamodels.fm_metamodel.transformations.featureide_reader import FeatureIDEReader
+from flamapy.metamodels.bdd_metamodel.operations import BDDProductDistribution
+from flamapy.metamodels.fm_metamodel.transformations.uvl_writer import UVLWriter
+from flamapy.metamodels.fm_metamodel.models import FeatureModel
 
 from montecarlo_framework.algorithms.montecarlo_algorithm import MonteCarloAlgorithm
 from montecarlo_framework.algorithms.stopping_conditions import IterationsStoppingCondition, TimeStoppingCondition, NoneStoppingCondition

--- a/montecarlo_framework/models/feature_model/fm_configuration.py
+++ b/montecarlo_framework/models/feature_model/fm_configuration.py
@@ -4,13 +4,13 @@ from typing import Optional
 
 from pysat.solvers import Glucose3
 
-from famapy.core.models import Configuration
-from famapy.metamodels.fm_metamodel.models import FeatureModel, Feature
-from famapy.metamodels.pysat_metamodel.operations.glucose3_valid_configuration import Glucose3ValidConfiguration
-from famapy.metamodels.pysat_metamodel.operations.glucose3_valid_product import Glucose3ValidProduct
-from famapy.metamodels.pysat_metamodel.operations.glucose3_products import Glucose3Products
-from famapy.metamodels.pysat_metamodel.transformations.fm_to_pysat import FmToPysat
-from famapy.metamodels.bdd_metamodel.transformations.fm_to_bdd import FmToBDD
+from flamapy.metamodels.configuration_metamodel.models.configuration import Configuration
+from flamapy.metamodels.fm_metamodel.models import FeatureModel, Feature
+from flamapy.metamodels.pysat_metamodel.operations.glucose3_valid_configuration import Glucose3ValidConfiguration
+from flamapy.metamodels.pysat_metamodel.operations.glucose3_valid_product import Glucose3ValidProduct
+from flamapy.metamodels.pysat_metamodel.operations.glucose3_products import Glucose3Products
+from flamapy.metamodels.pysat_metamodel.transformations.fm_to_pysat import FmToPysat
+from flamapy.metamodels.bdd_metamodel.transformations.fm_to_bdd import FmToBDD
 from montecarlo_framework.models.feature_model import fm_utils
 
 

--- a/montecarlo_framework/models/feature_model/fm_utils.py
+++ b/montecarlo_framework/models/feature_model/fm_utils.py
@@ -1,9 +1,9 @@
 from collections.abc import Iterable
 from enum import Enum, auto 
 
-from famapy.core.models import Configuration
-from famapy.metamodels.fm_metamodel.models import FeatureModel, Feature
-from famapy.metamodels.fm_metamodel.operations import get_core_features
+from flamapy.metamodels.configuration_metamodel.models.configuration import Configuration
+from flamapy.metamodels.fm_metamodel.models import FeatureModel, Feature
+from flamapy.metamodels.fm_metamodel.operations import get_core_features
 
 
 class RelationType(Enum):

--- a/montecarlo_framework/models/feature_model/op2_fm_configuration.py
+++ b/montecarlo_framework/models/feature_model/op2_fm_configuration.py
@@ -4,12 +4,12 @@ from typing import Optional
 
 from pysat.solvers import Glucose3
 
-from famapy.core.models import Configuration
-from famapy.metamodels.fm_metamodel.models import FeatureModel, Feature
-from famapy.metamodels.pysat_metamodel.operations.glucose3_valid_configuration import Glucose3ValidConfiguration
-from famapy.metamodels.pysat_metamodel.operations.glucose3_valid_product import Glucose3ValidProduct
-from famapy.metamodels.pysat_metamodel.transformations.fm_to_pysat import FmToPysat
-from famapy.metamodels.bdd_metamodel.transformations.fm_to_bdd import FmToBDD
+from flamapy.metamodels.configuration_metamodel.models.configuration import Configuration
+from flamapy.metamodels.fm_metamodel.models import FeatureModel, Feature
+from flamapy.metamodels.pysat_metamodel.operations.glucose3_valid_configuration import Glucose3ValidConfiguration
+from flamapy.metamodels.pysat_metamodel.operations.glucose3_valid_product import Glucose3ValidProduct
+from flamapy.metamodels.pysat_metamodel.transformations.fm_to_pysat import FmToPysat
+from flamapy.metamodels.bdd_metamodel.transformations.fm_to_bdd import FmToBDD
 
 
 class FM(FeatureModel):

--- a/montecarlo_framework/models/feature_model/opt_fm_configuration.py
+++ b/montecarlo_framework/models/feature_model/opt_fm_configuration.py
@@ -4,12 +4,12 @@ from typing import Optional
 
 from pysat.solvers import Glucose3
 
-from famapy.core.models import Configuration
-from famapy.metamodels.fm_metamodel.models import FeatureModel, Feature
-from famapy.metamodels.pysat_metamodel.operations.glucose3_valid_configuration import Glucose3ValidConfiguration
-from famapy.metamodels.pysat_metamodel.operations.glucose3_valid_product import Glucose3ValidProduct
-from famapy.metamodels.pysat_metamodel.transformations.fm_to_pysat import FmToPysat
-from famapy.metamodels.bdd_metamodel.transformations.fm_to_bdd import FmToBDD
+from flamapy.metamodels.configuration_metamodel.models.configuration import Configuration
+from flamapy.metamodels.fm_metamodel.models import FeatureModel, Feature
+from flamapy.metamodels.pysat_metamodel.operations.glucose3_valid_configuration import Glucose3ValidConfiguration
+from flamapy.metamodels.pysat_metamodel.operations.glucose3_valid_product import Glucose3ValidProduct
+from flamapy.metamodels.pysat_metamodel.transformations.fm_to_pysat import FmToPysat
+from flamapy.metamodels.bdd_metamodel.transformations.fm_to_bdd import FmToBDD
 
 
 class FM(FeatureModel):

--- a/montecarlo_framework/models/feature_model/optimized_fm_configuration.py
+++ b/montecarlo_framework/models/feature_model/optimized_fm_configuration.py
@@ -4,12 +4,12 @@ from typing import Optional
 
 from pysat.solvers import Glucose3
 
-from famapy.core.models import Configuration
-from famapy.metamodels.fm_metamodel.models import FeatureModel, Feature
-from famapy.metamodels.pysat_metamodel.operations.glucose3_valid_configuration import Glucose3ValidConfiguration
-from famapy.metamodels.pysat_metamodel.operations.glucose3_valid_product import Glucose3ValidProduct
-from famapy.metamodels.pysat_metamodel.transformations.fm_to_pysat import FmToPysat
-from famapy.metamodels.bdd_metamodel.transformations.fm_to_bdd import FmToBDD
+from flamapy.metamodels.configuration_metamodel.models.configuration import Configuration
+from flamapy.metamodels.fm_metamodel.models import FeatureModel, Feature
+from flamapy.metamodels.pysat_metamodel.operations.glucose3_valid_configuration import Glucose3ValidConfiguration
+from flamapy.metamodels.pysat_metamodel.operations.glucose3_valid_product import Glucose3ValidProduct
+from flamapy.metamodels.pysat_metamodel.transformations.fm_to_pysat import FmToPysat
+from flamapy.metamodels.bdd_metamodel.transformations.fm_to_bdd import FmToBDD
 
 
 class FM(FeatureModel):

--- a/montecarlo_framework/problems/configuration_based_analyses/configuration_state.py
+++ b/montecarlo_framework/problems/configuration_based_analyses/configuration_state.py
@@ -1,9 +1,9 @@
 import random 
 from abc import abstractmethod
 
-from famapy.core.models import Configuration
-from famapy.metamodels.fm_metamodel.models import Feature
-from famapy.metamodels.bdd_metamodel.operations import random_configuration
+from flamapy.metamodels.configuration_metamodel.models.configuration import Configuration
+from flamapy.metamodels.fm_metamodel.models import Feature
+from flamapy.metamodels.bdd_metamodel.operations import random_configuration
 
 from montecarlo_framework.models.problem import State, Action
 from montecarlo_framework.models.feature_model import FMConfiguration

--- a/montecarlo_framework/problems/configuration_based_analyses/jhipster_utils.py
+++ b/montecarlo_framework/problems/configuration_based_analyses/jhipster_utils.py
@@ -2,7 +2,7 @@ import csv
 import ast
 import random 
 
-from famapy.metamodels.fm_metamodel.transformations.featureide_reader import FeatureIDEReader
+from flamapy.metamodels.fm_metamodel.transformations.featureide_reader import FeatureIDEReader
 
 from montecarlo_framework.models.feature_model import FMConfiguration, FM
 

--- a/montecarlo_framework/problems/configuration_based_analyses/optimize_config_state.py
+++ b/montecarlo_framework/problems/configuration_based_analyses/optimize_config_state.py
@@ -2,7 +2,7 @@ import statistics
 import datetime
 from typing import Any 
 
-from famapy.metamodels.fm_metamodel.models import Feature 
+from flamapy.metamodels.fm_metamodel.models import Feature 
 
 from montecarlo_framework.models import Problem
 from montecarlo_framework.models.feature_model import FMConfiguration

--- a/montecarlo_framework/problems/fm_based_analyses/fm_state.py
+++ b/montecarlo_framework/problems/fm_based_analyses/fm_state.py
@@ -3,7 +3,7 @@ import itertools
 import random
 from functools import reduce
 
-from famapy.metamodels.fm_metamodel.models import FeatureModel, Feature, Relation
+from flamapy.metamodels.fm_metamodel.models import FeatureModel, Feature, Relation
 from montecarlo_framework.models.feature_model import FM, FMConfiguration
 from montecarlo_framework.models import State, Action, Problem
 

--- a/montecarlo_framework/utils/attributes_csv_reader.py
+++ b/montecarlo_framework/utils/attributes_csv_reader.py
@@ -2,7 +2,7 @@ import csv
 import datetime
 from typing import Any 
 
-from famapy.metamodels.fm_metamodel.models import (
+from flamapy.metamodels.fm_metamodel.models import (
     Feature,
     FeatureModel
 )

--- a/montecarlo_framework/utils/heatmap.py
+++ b/montecarlo_framework/utils/heatmap.py
@@ -1,7 +1,7 @@
 import csv
 from collections import defaultdict
 
-from famapy.metamodels.fm_metamodel.models import FeatureModel, Feature
+from flamapy.metamodels.fm_metamodel.models import FeatureModel, Feature
 from montecarlo_framework.models import State
 
 

--- a/montecarlo_framework/utils/montecarlo_heatmap.py
+++ b/montecarlo_framework/utils/montecarlo_heatmap.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass, field
 from contextlib import ContextDecorator
 from typing import Any, Callable, ClassVar, Dict, Optional
 
-from famapy.metamodels.fm_metamodel.models import Feature 
+from flamapy.metamodels.fm_metamodel.models import Feature 
 
 from montecarlo_framework.models import Node, State
 from montecarlo_framework.algorithms.montecarlo_algorithm import MonteCarloAlgorithm

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
-famapy==0.1.0
-famapy-fm==0.1.0
-famapy-sat==0.1.0
+flamapy==1.0.1
+flamapy-bdd==1.0.1
+flamapy-fm==1.0.1
+flamapy-sat==1.0.1
 graphviz==0.16
-python-sat==0.1.5.dev16
+python-sat==0.1.7.dev21
 six==1.15.0

--- a/tests/check_reproducibility.py
+++ b/tests/check_reproducibility.py
@@ -1,14 +1,14 @@
 import random 
 
-from famapy.core.models import Configuration
-from famapy.metamodels.fm_metamodel.transformations.featureide_reader import FeatureIDEReader
+from flamapy.metamodels.configuration_metamodel.models.configuration import Configuration
+from flamapy.metamodels.fm_metamodel.transformations.featureide_reader import FeatureIDEReader
 
 from montecarlo_framework.models.feature_model import FM, FMConfiguration
 from montecarlo_framework.algorithms import FlatMonteCarlo, AStarSearch
 from montecarlo_framework.algorithms.stopping_conditions import IterationsStoppingCondition, NoneStoppingCondition
 from montecarlo_framework.algorithms.selection_criterias import MaxChild
 from montecarlo_framework.models.feature_model.fm_configuration import FMConfiguration
-from montecarlo_framework.problems.configuration_based_analyses.valid_min_config import ValidMinimumConfigurationState, FindAllValidMinimumConfigurationState, ValidMinConfigProblem
+from montecarlo_framework.problems.configuration_based_analyses.valid_min_config_state import ValidMinimumConfigurationState, FindAllValidMinimumConfigurationState, ValidMinConfigProblem
 
 
 INPUT_MODEL = 'input_fms/pizzas.xml'

--- a/tests/generate_latex_table_fm_metrics.py
+++ b/tests/generate_latex_table_fm_metrics.py
@@ -1,8 +1,8 @@
-from famapy.metamodels.fm_metamodel.models import FeatureModel
-from famapy.metamodels.fm_metamodel.operations import FMEstimatedProductsNumber, average_branching_factor, max_depth_tree
-from famapy.metamodels.fm_metamodel.transformations.featureide_reader import FeatureIDEReader
-from famapy.metamodels.bdd_metamodel.operations import BDDProductsNumber
-from famapy.metamodels.bdd_metamodel.transformations.fm_to_bdd import FmToBDD
+from flamapy.metamodels.fm_metamodel.models import FeatureModel
+from flamapy.metamodels.fm_metamodel.operations import FMEstimatedProductsNumber, average_branching_factor, max_depth_tree
+from flamapy.metamodels.fm_metamodel.transformations.featureide_reader import FeatureIDEReader
+from flamapy.metamodels.bdd_metamodel.operations import BDDProductsNumber
+from flamapy.metamodels.bdd_metamodel.transformations.fm_to_bdd import FmToBDD
 
 from models.models_info import *
 

--- a/tests/glucose_sampling.py
+++ b/tests/glucose_sampling.py
@@ -1,9 +1,9 @@
-from famapy.metamodels.fm_metamodel.models import FeatureModel
-from famapy.metamodels.fm_metamodel.operations import FMEstimatedProductsNumber, average_branching_factor
-from famapy.metamodels.fm_metamodel.transformations.featureide_reader import FeatureIDEReader
-from famapy.metamodels.bdd_metamodel.operations import BDDProductsNumber
-from famapy.metamodels.bdd_metamodel.transformations.fm_to_bdd import FmToBDD
-from famapy.metamodels.pysat_metamodel.transformations.fm_to_pysat import FmToPysat
+from flamapy.metamodels.fm_metamodel.models import FeatureModel
+from flamapy.metamodels.fm_metamodel.operations import FMEstimatedProductsNumber, average_branching_factor
+from flamapy.metamodels.fm_metamodel.transformations.featureide_reader import FeatureIDEReader
+from flamapy.metamodels.bdd_metamodel.operations import BDDProductsNumber
+from flamapy.metamodels.bdd_metamodel.transformations.fm_to_bdd import FmToBDD
+from flamapy.metamodels.pysat_metamodel.transformations.fm_to_pysat import FmToPysat
 
 from models.models_info import *
 

--- a/tests/main_findall_valid_min_config_old.py
+++ b/tests/main_findall_valid_min_config_old.py
@@ -1,12 +1,12 @@
-from famapy.core.models import Configuration
-from famapy.metamodels.fm_metamodel.transformations.featureide_reader import FeatureIDEReader
+from flamapy.metamodels.configuration_metamodel.models.configuration import Configuration
+from flamapy.metamodels.fm_metamodel.transformations.featureide_reader import FeatureIDEReader
 
 from montecarlo_framework.models.feature_model import FM, FMConfiguration
 from montecarlo_framework.algorithms import FlatMonteCarlo, AStarSearch
 from montecarlo_framework.algorithms.stopping_conditions import IterationsStoppingCondition, NoneStoppingCondition
 from montecarlo_framework.algorithms.selection_criterias import MaxChild
 from montecarlo_framework.models.feature_model.fm_configuration import FMConfiguration
-from montecarlo_framework.problems.configuration_based_analyses.valid_min_config import ValidMinimumConfigurationState, FindAllValidMinimumConfigurationState, ValidMinConfigProblem
+from montecarlo_framework.problems.configuration_based_analyses.valid_min_config_state import ValidMinimumConfigurationState, FindAllValidMinimumConfigurationState, ValidMinConfigProblem
 
 
 INPUT_MODEL = 'input_fms/pizzas.xml'

--- a/tests/main_valid_min_config_runs_old.py
+++ b/tests/main_valid_min_config_runs_old.py
@@ -5,15 +5,15 @@ import os
 
 import matplotlib.pyplot as plt
 
-from famapy.core.models import Configuration
-from famapy.metamodels.fm_metamodel.transformations.featureide_reader import FeatureIDEReader
-from famapy.metamodels.bdd_metamodel.operations import BDDProductDistributionBF
+from flamapy.metamodels.configuration_metamodel.models.configuration import Configuration
+from flamapy.metamodels.fm_metamodel.transformations.featureide_reader import FeatureIDEReader
+from flamapy.metamodels.bdd_metamodel.operations import BDDProductDistribution
 
 from montecarlo_framework.models.feature_model import FM, FMConfiguration
 from montecarlo_framework.algorithms import FlatMonteCarlo, UCTMCTS, GreedyMCTS, RandomStrategy, AStarSearch
 from montecarlo_framework.algorithms.stopping_conditions import IterationsStoppingCondition, NoneStoppingCondition
 from montecarlo_framework.algorithms.selection_criterias import MaxChild
-from montecarlo_framework.problems.configuration_based_analyses.valid_min_config import ValidMinimumConfigurationState, ValidMinConfigProblem
+from montecarlo_framework.problems.configuration_based_analyses.valid_min_config_state import ValidMinimumConfigurationState, ValidMinConfigProblem
 from montecarlo_framework.models.feature_model import fm_utils
 
 
@@ -64,7 +64,7 @@ def main(input_fm: str, iterations: int, runs: int):
     fm.bdd_model = None
     # Serialize the product distribution
     if fm.bdd_model is not None:
-        pd_op = BDDProductDistributionBF().execute(fm.bdd_model)
+        pd_op = BDDProductDistribution().execute(fm.bdd_model)
         pd_op.serialize(f'{OUTPUT_RESULTS + fm.fm_model.root.name.lower()}_product_distribution.csv')
 
         # Plot the product distribution

--- a/tests/montecarlo_parallel_old.py
+++ b/tests/montecarlo_parallel_old.py
@@ -2,8 +2,8 @@ from multiprocessing.queues import Queue
 import time 
 import multiprocessing
 
-from famapy.metamodels.fm_metamodel.models import FeatureModel
-from famapy.metamodels.fm_metamodel.transformations.featureide_reader import FeatureIDEReader
+from flamapy.metamodels.fm_metamodel.models import FeatureModel
+from flamapy.metamodels.fm_metamodel.transformations.featureide_reader import FeatureIDEReader
 
 
 def do_something(fm: FeatureModel, result_queue: Queue):

--- a/tests/plot_product_distribution_old.py
+++ b/tests/plot_product_distribution_old.py
@@ -3,16 +3,16 @@ import random
 import numpy as np
 import matplotlib.pyplot as plt
 
-from famapy.core.models import Configuration
-from famapy.metamodels.fm_metamodel.transformations.featureide_reader import FeatureIDEReader
-from famapy.metamodels.bdd_metamodel.operations import BDDProductDistributionBF
+from flamapy.metamodels.configuration_metamodel.models.configuration import Configuration
+from flamapy.metamodels.fm_metamodel.transformations.featureide_reader import FeatureIDEReader
+from flamapy.metamodels.bdd_metamodel.operations import BDDProductDistribution
 
 
 from montecarlo_framework.models.feature_model import FM, FMConfiguration
 from montecarlo_framework.algorithms import FlatMonteCarlo, UCTMCTS, AStarSearch
 from montecarlo_framework.algorithms.stopping_conditions import IterationsStoppingCondition, NoneStoppingCondition
 from montecarlo_framework.algorithms.selection_criterias import MaxChild
-from montecarlo_framework.problems.configuration_based_analyses.valid_min_config import ValidMinimumConfigurationState, FindAllValidMinimumConfigurationState, ValidMinConfigProblem
+from montecarlo_framework.problems.configuration_based_analyses.valid_min_config_state import ValidMinimumConfigurationState, FindAllValidMinimumConfigurationState, ValidMinConfigProblem
 from montecarlo_framework.utils.montecarlo_stats import MonteCarloStats
 from montecarlo_framework.utils.algorithm_stats import AlgorithmStats
 from montecarlo_framework.models.feature_model import fm_utils
@@ -28,7 +28,7 @@ INITIAL_CONFIGURATION_FEATURES = {}
 
 def plot_product_distribution(fm: FM, configurations: list[FMConfiguration] = None):
     # Calcualte the product distribution with BDD
-    dist = BDDProductDistributionBF().execute(fm.bdd_model).get_result()
+    dist = BDDProductDistribution().execute(fm.bdd_model).get_result()
     print(f'Product Distribution: {dist}')
 
     # Create data for the PD

--- a/tests/test_large_scale_fm.py
+++ b/tests/test_large_scale_fm.py
@@ -1,15 +1,15 @@
 import random
 
-from famapy.core.models import Configuration
-from famapy.metamodels.fm_metamodel.transformations.featureide_reader import FeatureIDEReader
-from famapy.metamodels.bdd_metamodel.operations import BDDProductDistributionBF
+from flamapy.metamodels.configuration_metamodel.models.configuration import Configuration
+from flamapy.metamodels.fm_metamodel.transformations.featureide_reader import FeatureIDEReader
+from flamapy.metamodels.bdd_metamodel.operations import BDDProductDistribution
 
 from montecarlo_framework.models.feature_model import FM, FMConfiguration
 from montecarlo_framework.algorithms import FlatMonteCarlo, UCTMCTS, AStarSearch
 from montecarlo_framework.algorithms.stopping_conditions import IterationsStoppingCondition, NoneStoppingCondition
 from montecarlo_framework.algorithms.selection_criterias import MaxChild
 from montecarlo_framework.models.feature_model.fm_configuration import FMConfiguration
-from montecarlo_framework.problems.configuration_based_analyses.valid_min_config import ValidMinimumConfigurationState, FindAllValidMinimumConfigurationState, ValidMinConfigProblem
+from montecarlo_framework.problems.configuration_based_analyses.valid_min_config_state import ValidMinimumConfigurationState, FindAllValidMinimumConfigurationState, ValidMinConfigProblem
 from montecarlo_framework.utils.montecarlo_stats import MonteCarloStats
 
 from montecarlo_framework.models.feature_model import fm_utils

--- a/tests/test_valid_min_config.py
+++ b/tests/test_valid_min_config.py
@@ -3,8 +3,8 @@ import sys
 
 import pytest
 
-from famapy.core.models import Configuration
-from famapy.metamodels.fm_metamodel.transformations.featureide_reader import FeatureIDEReader
+from flamapy.metamodels.configuration_metamodel.models.configuration import Configuration
+from flamapy.metamodels.fm_metamodel.transformations.featureide_reader import FeatureIDEReader
  
 # setting path
 sys.path.append('.')
@@ -14,7 +14,7 @@ from montecarlo_framework.algorithms import FlatMonteCarlo, AStarSearch, Algorit
 from montecarlo_framework.algorithms.stopping_conditions import IterationsStoppingCondition, NoneStoppingCondition
 from montecarlo_framework.algorithms.selection_criterias import MaxChild
 from montecarlo_framework.models.feature_model.fm_configuration import FMConfiguration
-from montecarlo_framework.problems.configuration_based_analyses.valid_min_config import ValidMinimumConfigurationState, FindAllValidMinimumConfigurationState, ValidMinConfigProblem
+from montecarlo_framework.problems.configuration_based_analyses.valid_min_config_state import ValidMinimumConfigurationState, FindAllValidMinimumConfigurationState, ValidMinConfigProblem
 
 
 # INDEX: ATTRIBUTE


### PR DESCRIPTION
This update changes requirements and imports so the tool stops using famapy and starts using flamapy instead. Some minor fixes to operations were also added as they were causing operations to fail.

However, there are still some issues which should be fixed. This is the current status of operations:

- **main_complete_partial_config** works fine
- **main_find_defective_config** works fine.
- **main_optimize_config** works fine. The command feedback used to diplay jhipster as an available input while it currently isn't, so the feedback message has been updated.

**main_reverse_engineering** is not working. To reproduce the issue:
```python main_reverse_engineering.py -fm models/pizzas.xml```
It will return:
![image](https://user-images.githubusercontent.com/43904563/211809246-4957ebb3-fa4d-4d3e-ae36-d1ac04d5223c.png)

By debugging, I have found out that the error is triggered in the class Node in montecarlo_framework/models/search_space.py

![image](https://user-images.githubusercontent.com/43904563/211810597-5920558c-08b3-4fa7-9be5-62a903cf479b.png)

where there is an instance of this class being somewhere created, with no action object at all, not even one with a None value.

![image](https://user-images.githubusercontent.com/43904563/211811629-2ac4fd76-da28-49b7-8dd7-32b0191b7634.png)

This seems to be causing the error but I can't figure out why this happens.
